### PR TITLE
clean up CheetahTireParticle sizes. 

### DIFF
--- a/datablocks/vehicles/cheetahCar.tscript
+++ b/datablocks/vehicles/cheetahCar.tscript
@@ -39,7 +39,7 @@ datablock ParticleData(CheetahTireParticle)
    colors[0]            = "0.456693 0.354331 0.259843 1";
    colors[1]            = "0.456693 0.456693 0.354331 0";
    sizes[0]             = "0.99794";
-   sizes[1]             = "3.99786";
+   sizes[1]             = "0.99794";
    sizes[2]             = "1.0";
    sizes[3]             = "1.0";
    times[0]             = "0.0";
@@ -57,7 +57,7 @@ datablock ParticleEmitterData(CheetahTireEmitter)
 {
    ejectionPeriodMS = 20;
    periodVarianceMS = 10;
-   ejectionVelocity = "14.57";
+   ejectionVelocity = "1";
    velocityVariance = 1.0;
    ejectionOffset   = 0.0;
    thetaMin         = 0;


### PR DESCRIPTION
they were about 4 times larger, and the emitter spewed at 14 times the rate, for ground-contact smoke